### PR TITLE
Fix glacier.utils.validate_multipart_bytes(2**29)

### DIFF
--- a/glacier/utils.py
+++ b/glacier/utils.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import math
 import os
 import errno
 
@@ -19,7 +18,5 @@ def validate_multipart_bytes(num_bytes):
     """Amazon requires multipart uploads/downloads to be in multiples of
     1MB powers of 2 (ie: 1MB, 2MB, 4MB, 8MB, 16MB, 32MB, etc), up to 4GB"""
     error = ValueError('Part size must be a power of two and be between 1048576 and 4294967296 bytes.')
-    if num_bytes < 1024**2 or num_bytes > (1024**2)*4096:
-        raise error
-    if not math.log(num_bytes, 2).is_integer():
+    if num_bytes not in [2**n for n in range(20,33)]:
         raise error


### PR DESCRIPTION
    >>> 1048576 <= 2**29 and 2**29 <= 4294967296
    True
    >>> glacier.utils.validate_multipart_bytes(2**29)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "glacier/utils.py", line 25, in validate_multipart_bytes
        raise error
    ValueError: Part size must be a power of two and be between 1048576 and 4294967296 bytes.